### PR TITLE
Copyright header added in the XrayTo3DShape folder

### DIFF
--- a/XrayTo3DShape/__init__.py
+++ b/XrayTo3DShape/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from .utils.registry import import_all_modules_for_register
 
 import_all_modules_for_register()

--- a/XrayTo3DShape/architectures/__init__.py
+++ b/XrayTo3DShape/architectures/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+ 
 from ..utils.registry import ARCHITECTURES
 name2arch = ARCHITECTURES
 

--- a/XrayTo3DShape/architectures/arch_utils.py
+++ b/XrayTo3DShape/architectures/arch_utils.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """arch utils"""
 from typing import Sequence
 

--- a/XrayTo3DShape/architectures/atlas_deformation_stn.py
+++ b/XrayTo3DShape/architectures/atlas_deformation_stn.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """Atlas-deformation based encoder-decoder architecture
 TODO: work in progress
 """

--- a/XrayTo3DShape/architectures/autoencoder.py
+++ b/XrayTo3DShape/architectures/autoencoder.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """
 adapted from monai.networks.nets.varautoencoder
 The original Autoencoder in the monai.networks.nets.autoencoder does not have a

--- a/XrayTo3DShape/architectures/autoencoder_v2.py
+++ b/XrayTo3DShape/architectures/autoencoder_v2.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """
 adapted from monai.networks.nets.varautoencoder
 The original Autoencoder in the monai.networks.nets.autoencoder does not have a

--- a/XrayTo3DShape/architectures/get_model.py
+++ b/XrayTo3DShape/architectures/get_model.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 import math
 from typing import Dict
 

--- a/XrayTo3DShape/architectures/onedconcat.py
+++ b/XrayTo3DShape/architectures/onedconcat.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from typing import Dict, List
 
 import torch

--- a/XrayTo3DShape/architectures/twodpermuteconcat.py
+++ b/XrayTo3DShape/architectures/twodpermuteconcat.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from typing import Dict, List
 
 import torch

--- a/XrayTo3DShape/architectures/twodpermuteconcatmultiscale.py
+++ b/XrayTo3DShape/architectures/twodpermuteconcatmultiscale.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """Multiscale2DPermuteConcat
 3D reconstruction of proximal femoral fracture from biplanar radiographs with fractural representative learning
 Authors: Danupong Buttongkum et al.

--- a/XrayTo3DShape/consts.py
+++ b/XrayTo3DShape/consts.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """
 Contains Image size of datasets from the preprocessing pipeline.
 returns model architecture-specific data transformation pipeline

--- a/XrayTo3DShape/datasets/__init__.py
+++ b/XrayTo3DShape/datasets/__init__.py
@@ -1,2 +1,8 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from .base_dataset import (AtlasDeformationDataset, BaseDataset,
                            DeformationDataset, get_dataset)

--- a/XrayTo3DShape/datasets/base_dataset.py
+++ b/XrayTo3DShape/datasets/base_dataset.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """
 Define torch Datasets for AP, LAT, Segmentation images
 TODO: subclass from monai.data.PersistentDataset for caching

--- a/XrayTo3DShape/experiments/__init__.py
+++ b/XrayTo3DShape/experiments/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from .base_experiment import BaseExperiment
 from .experiments import (
     AutoencoderExperiment,

--- a/XrayTo3DShape/experiments/base_experiment.py
+++ b/XrayTo3DShape/experiments/base_experiment.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """Base class with common functionality for encoder-decoder based methods"""
 from typing import Any, Optional, Tuple
 

--- a/XrayTo3DShape/experiments/experiments.py
+++ b/XrayTo3DShape/experiments/experiments.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """Architecture specific training regime
 
 VolumeAsInput

--- a/XrayTo3DShape/losses/__init__.py
+++ b/XrayTo3DShape/losses/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from .get_loss import get_loss, l1_loss
 from .hausdorff import HausdorffDTLoss, HausdorffERLoss
 from .losses_zoo import DiceCELoss, NGCCLoss

--- a/XrayTo3DShape/losses/get_loss.py
+++ b/XrayTo3DShape/losses/get_loss.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """interface for losses zoo"""
 import torch
 from monai.losses.dice import DiceLoss

--- a/XrayTo3DShape/losses/hausdorff.py
+++ b/XrayTo3DShape/losses/hausdorff.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """
 from https://github.com/JunMa11/SegLoss/blob/master/losses_pytorch/hausdorff.py
 

--- a/XrayTo3DShape/losses/losses_zoo.py
+++ b/XrayTo3DShape/losses/losses_zoo.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """custom losses """
 from typing import Optional
 

--- a/XrayTo3DShape/transforms/__init__.py
+++ b/XrayTo3DShape/transforms/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from .base_transforms import (get_denoising_autoencoder_transforms,
                               get_kasten_transforms, get_nonkasten_transforms,
                               get_resize_transform)

--- a/XrayTo3DShape/transforms/base_transforms.py
+++ b/XrayTo3DShape/transforms/base_transforms.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """specialized data transformation specific to model architecture"""
 from typing import Sequence
 

--- a/XrayTo3DShape/transforms/deformable_transforms.py
+++ b/XrayTo3DShape/transforms/deformable_transforms.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """Work in Progress: Data transformation pipeline for Atlas-deformation based architecture"""
 from monai.transforms.spatial.dictionary import ResizeD, SpacingD, OrientationD
 from monai.transforms.intensity.dictionary import ThresholdIntensityD, ScaleIntensityD

--- a/XrayTo3DShape/transforms/post_transform.py
+++ b/XrayTo3DShape/transforms/post_transform.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """data transformation for post-processing model prediction """
 from monai.transforms.compose import Compose
 from monai.transforms.post.array import Activations

--- a/XrayTo3DShape/utils/__init__.py
+++ b/XrayTo3DShape/utils/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from .np_utils import *
 from .io_utils import *
 from .np_show import *

--- a/XrayTo3DShape/utils/callbacks.py
+++ b/XrayTo3DShape/utils/callbacks.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """custom pytorch-lightning callbacks for saving model prediction
 and evaluating metrics."""
 import copy

--- a/XrayTo3DShape/utils/config_template.py
+++ b/XrayTo3DShape/utils/config_template.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """
 template for config file
 id: sample id of each ct scan

--- a/XrayTo3DShape/utils/config_utils.py
+++ b/XrayTo3DShape/utils/config_utils.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """utils for working with dicts"""
 from collections import ChainMap
 import copy

--- a/XrayTo3DShape/utils/enums.py
+++ b/XrayTo3DShape/utils/enums.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from enum import Enum
 
 

--- a/XrayTo3DShape/utils/io_utils.py
+++ b/XrayTo3DShape/utils/io_utils.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """utils for i/o operations"""
 from pathlib import Path
 import SimpleITK as sitk

--- a/XrayTo3DShape/utils/misc_utils.py
+++ b/XrayTo3DShape/utils/misc_utils.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """utils that do not belong anywhere else or do not require separate module yet"""
 import re
 from pathlib import Path

--- a/XrayTo3DShape/utils/np_show.py
+++ b/XrayTo3DShape/utils/np_show.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """utils to visualize numpy volume"""
 import math
 

--- a/XrayTo3DShape/utils/np_utils.py
+++ b/XrayTo3DShape/utils/np_utils.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """utils for numpy array"""
 from pathlib import Path
 from typing import List, Union

--- a/XrayTo3DShape/utils/print_arr.py
+++ b/XrayTo3DShape/utils/print_arr.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """ 
     Author: Nicholas Sharp (nmwsharp.com)
     Canonical source: https://gist.github.com/nmwsharp/54d04af87872a4988809f128e1a1d233

--- a/XrayTo3DShape/utils/registry.py
+++ b/XrayTo3DShape/utils/registry.py
@@ -1,4 +1,12 @@
-# code from https://github.com/microsoft/Semi-supervised-learning/blob/main/semilearn/core/utils/registry.py
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
+# Code adapted from https://github.com/microsoft/Semi-supervised-learning/blob/main/semilearn/core/utils/registry.py
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
 
 import importlib
 

--- a/XrayTo3DShape/utils/verse_metadata.py
+++ b/XrayTo3DShape/utils/verse_metadata.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """query verse metadata"""
 import math
 import warnings

--- a/XrayTo3DShape/utils/wandb_utils.py
+++ b/XrayTo3DShape/utils/wandb_utils.py
@@ -1,0 +1,4 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# see https://www.gnu.org/licenses/gpl-3.0.html for details.

--- a/evaluate.py
+++ b/evaluate.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """
 run inference using model checkpoint.
 save metrics to csv log, predictions as nifti

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 from setuptools import find_packages, setup
 
 setup(

--- a/train.py
+++ b/train.py
@@ -1,3 +1,9 @@
+# Copyright (c) NAAMII, Nepal.
+# For more information, visit https://www.naamii.org.np.
+# Licensed under the GNU General Public License v3.0 (GPL-3.0).
+# See https://www.gnu.org/licenses/gpl-3.0.html for details.
+
+
 """
 script to train various architectures on given dataset
 (defined by training and validation filepaths).


### PR DESCRIPTION
# Pull Request: Add Copyright Header and License Information to README.md

## Summary:
This pull request updates the  file in folder XrayTo3DShape folder to include the required copyright header and licensing information for the project. This change ensures compliance with the GNU General Public License (GPL-3.0) and provides proper attribution to the copyright holder.

## Changes:
- Added the following copyright and license information to the top of  all file in folder XrayTo3DShape folder
```
Copyright (c) NAAMII, Nepal.
For more information, visit https://www.naamii.org.np.
Licensed under the GNU General Public License v3.0 (GPL-3.0).
See https://www.gnu.org/licenses/gpl-3.0.html for details. 
```
## Issue Reference:
Fixes #37 


  
